### PR TITLE
fix: Add `OPTIONS` in allow methods

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-slim-trixie AS builder
+FROM rust:1.90.0-slim-trixie AS builder
 RUN apt-get update && apt-get install -y pkg-config libssl-dev
 WORKDIR /app
 COPY . .

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -69,7 +69,7 @@ fn app() -> Router {
                             || origin.as_bytes().ends_with(b".vercel.app")
                     },
                 ))
-                .allow_methods([Method::GET])
+                .allow_methods([Method::GET, Method::OPTIONS])
                 .allow_headers([AUTHORIZATION, ACCEPT])
                 .max_age(Duration::from_secs(60) * 5),
         )


### PR DESCRIPTION
- Add `OPTIONS` in `allow_methods` in Rust backend
- Update to `rust:1.90.0-slim-trixie`  in Dockerfile